### PR TITLE
Fix command tsnpssp to use an async function as described in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ const FileName: NextPage<Props> = () => {
   return <div></div>
 }
 
-export const getServerSideProps: GetServerSideProps = (context) => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {},
   }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -212,7 +212,7 @@
       "\t)",
       "}",
       "",
-      "export const getServerSideProps: GetServerSideProps = (context) => {",
+      "export const getServerSideProps: GetServerSideProps = async (context) => {",
       "\treturn {",
       "\t\tprops: {}",
       "\t}",


### PR DESCRIPTION
Hi, 
Always when I use the snippet `tsnpssp`, the vscode show me a syntax error like the image bellow:
![image](https://user-images.githubusercontent.com/35784268/108449272-f7288280-7241-11eb-9cff-61b419c0ec63.png)  

So I went to the [docs](https://nextjs.org/docs/basic-features/data-fetching#typescript-use-getserversideprops) and I saw that this function is used with `async` command, like bellow:
![image](https://user-images.githubusercontent.com/35784268/108449474-5090b180-7242-11eb-891c-ab786b2e4f05.png)

Because of that, I made this PR. =]
I hope this help =]